### PR TITLE
GCP load balancer healthchecks target router port 8002

### DIFF
--- a/ci/planpatches/terraform/istio-router.tf
+++ b/ci/planpatches/terraform/istio-router.tf
@@ -1,8 +1,7 @@
-# TODO(gabe): do we need a firewall rule to allow this healthcheck?
 resource "google_compute_http_health_check" "cf-istio-router" {
   name         = "${var.env_id}-cf-istio-router"
-  port         = 8001
-  request_path = "/healthcheck/ok"
+  port         = 8002
+  request_path = "/healthcheck"
 }
 
 resource "google_compute_target_pool" "cf-istio-router" {
@@ -35,7 +34,7 @@ resource "google_compute_firewall" "cf-istio-router-health-check" {
 
   allow {
     protocol = "tcp"
-    ports    = ["8001"]
+    ports    = ["8002"]
   }
 
   source_ranges = ["209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]

--- a/deploy/bbl-config/terraform/istio-router.tf
+++ b/deploy/bbl-config/terraform/istio-router.tf
@@ -1,8 +1,7 @@
-# TODO(gabe): do we need a firewall rule to allow this healthcheck?
 resource "google_compute_http_health_check" "cf-istio-router" {
   name         = "${var.env_id}-cf-istio-router"
-  port         = 8001
-  request_path = "/healthcheck/ok"
+  port         = 8002
+  request_path = "/healthcheck"
 }
 
 resource "google_compute_target_pool" "cf-istio-router" {
@@ -35,7 +34,7 @@ resource "google_compute_firewall" "cf-istio-router-health-check" {
 
   allow {
     protocol = "tcp"
-    ports    = ["8001"]
+    ports    = ["8002"]
   }
 
   source_ranges = ["209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]


### PR DESCRIPTION
without this change, the envoy logs on istio-router show http 400 error codes and log lines about

    admin path "/healthcheck/ok" mutates state, method=GET rather than POST
