### PR TITLE
istio routers node id meet requirements for Pilot

### DIFF
--- a/jobs/envoy/templates/bpm.yml.erb
+++ b/jobs/envoy/templates/bpm.yml.erb
@@ -5,8 +5,6 @@ processes:
   args:
   - -c /var/vcap/jobs/envoy/config/envoy.json
   - --max-obj-name-len 200
-  - --service-cluster x
-  - --service-node router~x~x~x
   - --v2-config-only
   capabilities:
   - NET_BIND_SERVICE

--- a/jobs/envoy/templates/envoy.json.erb
+++ b/jobs/envoy/templates/envoy.json.erb
@@ -7,8 +7,8 @@
 
 config = {
   "node": {
-    "id": "router~x~x~x",
-    "cluster": "x"
+    "id": "router~#{spec.ip}~#{spec.id}~x",
+    "cluster": "istio-router"
   },
   "admin": {
     "access_log_path": "/dev/stdout",


### PR DESCRIPTION
- pilot expects ip address in 2nd position, and unique id
  in third position

- remove service-cluster and service-node from command-line
  just use config in the envoy.json instead

[#163248104]